### PR TITLE
More logging, limit to one change per config call, and fixed date parsing on removal.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -153,9 +153,9 @@
       }
     },
     "acorn": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -380,9 +380,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -556,9 +556,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.4.0.tgz",
-      "integrity": "sha512-gU+lxhlPHu45H3JkEGgYhWhkR9wLHHEXC9FbWFnTlEkbKyZKWgWRLgf61E8zWmBuI6g5xKBph9ltg3NtZMVF8g==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.7.0.tgz",
+      "integrity": "sha512-1KUxLzos0ZVsyL81PnRN335nDtQ8/vZUD6uMtWbF+5zDtjKcsklIi78XoE0MVL93QvWTu+E5y44VyyCsOMBrIg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -569,9 +569,9 @@
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
         "eslint-scope": "^5.1.0",
-        "eslint-utils": "^2.0.0",
-        "eslint-visitor-keys": "^1.2.0",
-        "espree": "^7.1.0",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^1.3.0",
+        "espree": "^7.2.0",
         "esquery": "^1.2.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
@@ -585,7 +585,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -606,6 +606,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-config-strongloop": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-strongloop/-/eslint-config-strongloop-2.1.0.tgz",
+      "integrity": "sha1-dj3Rmt/OiNewBR5uJV8a43eDtMY=",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.0",
@@ -633,14 +639,14 @@
       "dev": true
     },
     "espree": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
-      "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.2.0",
+        "acorn": "^7.4.0",
         "acorn-jsx": "^5.2.0",
-        "eslint-visitor-keys": "^1.2.0"
+        "eslint-visitor-keys": "^1.3.0"
       }
     },
     "esprima": {
@@ -658,9 +664,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
-          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
           "dev": true
         }
       }
@@ -1089,9 +1095,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lowercase-keys": {
@@ -1621,9 +1627,9 @@
       }
     },
     "strip-json-comments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "replicaset"
   ],
   "devDependencies": {
-    "eslint": "^7.4.0"
+    "eslint": "^7.7.0",
+    "eslint-config-strongloop": "^2.1.0"
   },
   "dependencies": {
     "ip": "^1.1.5",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -101,7 +101,7 @@ module.exports = {
   mongoTLSServerIdentityCheck: stringToBool(process.env.MONGO_TLS_IDENTITY_CHECK),
 
   loopSleepSeconds: process.env.SIDECAR_SLEEP_SECONDS || 5,
-  unhealthySeconds: process.env.SIDECAR_UNHEALTHY_SECONDS || 15,
+  unhealthySeconds: process.env.SIDECAR_UNHEALTHY_SECONDS || 30,
   env: process.env.NODE_ENV || 'local',
   isConfigRS: isConfigRS(),
 };

--- a/src/lib/mongo.js
+++ b/src/lib/mongo.js
@@ -123,7 +123,7 @@ const replSetReconfig = (db, rsConfig, force) => {
 const addNewReplSetMembers = async (db, addrToAdd, addrToRemove, shouldForce) => {
   try {
     let rsConfig = await replSetGetConfig(db);
-	let limit = { count: (shouldForce?100:1} };
+	let limit = { count: (shouldForce?100:1) };
     removeDeadMembers(rsConfig, addrToRemove, limit);
     addNewMembers(rsConfig, addrToAdd, limit);
     return replSetReconfig(db, rsConfig, shouldForce);

--- a/src/lib/mongo.js
+++ b/src/lib/mongo.js
@@ -58,7 +58,7 @@ const getClient = async host => {
     sslPass: config.mongoTLSPassword,
     checkServerIdentity: config.mongoTLSServerIdentityCheck,
     useNewUrlParser: true,
-	useUnifiedTopology: true
+    useUnifiedTopology: true
   };
 
   try {
@@ -123,7 +123,7 @@ const replSetReconfig = (db, rsConfig, force) => {
 const addNewReplSetMembers = async (db, addrToAdd, addrToRemove, shouldForce) => {
   try {
     let rsConfig = await replSetGetConfig(db);
-	let limit = { count: (shouldForce?100:1) };
+    let limit = { count: (shouldForce?100:1) };
     removeDeadMembers(rsConfig, addrToRemove, limit);
     addNewMembers(rsConfig, addrToAdd, limit);
     return replSetReconfig(db, rsConfig, shouldForce);
@@ -164,7 +164,7 @@ const addNewMembers = (rsConfig, addrsToAdd, limit) => {
     };
 
     rsConfig.members.push(cfg);
-	limit.count--;
+    limit.count--;
   }
 };
 
@@ -175,7 +175,7 @@ const removeDeadMembers = (rsConfig, addrsToRemove, limit) => {
     for (const i in rsConfig.members) {
       if (rsConfig.members[i].host === addr && limit.count > 0) {
         rsConfig.members.splice(i, 1);
-		limit.count--;
+        limit.count--;
         break;
       }
     }

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -261,9 +261,17 @@ const addrToRemoveLoop = members => {
   return addrToRemove;
 };
 
-const memberShouldBeRemoved = member => !member.health
-      && DateTime.fromISO(member.lastHeartbeatRecv).valueOf() + { seconds: unhealthySeconds }*1000 > DateTime.utc();
-
+const memberShouldBeRemoved = member => {
+	if (!member.health)
+	{
+      let lastHeartbeatTick = DateTime.fromISO(member.lastHeartbeatRecv).valueOf();
+      let nowTick = DateTime.utc();
+	  console.info('Member: '+member.name+' Last Heartbeat: '+lastHeartbeatTick+'  Now: '+nowTick);
+	  if (lastHeartbeatTick + unhealthySeconds*1000 < nowTick)
+		return true;
+	}
+	return false;
+}
 /**
  * @param pod this is the Kubernetes pod, containing the info.
  * @returns string - podIp the pod's IP address with the port from config attached at the end. Example

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -264,7 +264,7 @@ const addrToRemoveLoop = members => {
 const memberShouldBeRemoved = member => {
 	if (!member.health)
 	{
-      let lastHeartbeatTick = DateTime.fromISO(member.lastHeartbeatRecv).valueOf();
+      let lastHeartbeatTick = Date.parse(member.lastHeartbeatRecv);
       let nowTick = DateTime.utc();
 	  console.info('Member: '+member.name+' Last Heartbeat: '+lastHeartbeatTick+'  Now: '+nowTick);
 	  if (lastHeartbeatTick + unhealthySeconds*1000 < nowTick)

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -129,6 +129,9 @@ const inReplicaSet = async (db, pods, status) => {
 
 const primaryWork = async (db, pods, members, shouldForce) => {
 
+  console.info('Members: ', members);
+  console.info('Pods: ', pods);
+
   // Loop over all the pods we have and see if any of them aren't in the current rs members array
   // If they aren't in there, add them
   const addrToAdd = addrToAddLoop(pods, members);

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -26,6 +26,7 @@ const init = async() => {
     hostIp = await lookup(hostName);
     hostIp = hostIp.address;
     hostIpAndPort = hostIp + ':' + config.mongoPort;
+	console.info('Running on host '+hostIpAndPort+' hostname '+hostName);
   } catch (err) {
     return Promise.reject(err);
   }
@@ -237,6 +238,7 @@ const addrToAddLoop = (pods, members) => {
       // If the node was not present, we prefer the stable network ID, if present.
       const addrToUse = podStableNetworkAddr || podIpAddr;
       addrToAdd.push(addrToUse);
+	  console.info('Detected new pod not in replicaset: '+addrToUse);
     }
   }
   return addrToAdd;
@@ -247,6 +249,7 @@ const addrToRemoveLoop = members => {
   for (const member of members) {
     if (memberShouldBeRemoved(member)) {
       addrToRemove.push(member.name);
+	  console.info('Detected unhealthy/missing pod in replicaset: '+member.name);
     }
   }
   return addrToRemove;

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -26,7 +26,7 @@ const init = async() => {
     hostIp = await lookup(hostName);
     hostIp = hostIp.address;
     hostIpAndPort = hostIp + ':' + config.mongoPort;
-	console.info('Running on host '+hostIpAndPort+' hostname '+hostName);
+    console.info('Running on host '+hostIpAndPort+' hostname '+hostName);
   } catch (err) {
     return Promise.reject(err);
   }
@@ -107,13 +107,11 @@ const inReplicaSet = async (db, pods, status) => {
   // If we're already in a rs and NO ONE is a primary, elect someone to do the work for a primary
   const members = status.members;
 
-  let primaryExists = false;
   for (const member of members) {
     if (member.state === 1) {
       if (member.self) return primaryWork(db, pods, members, false);
 
-      primaryExists = true;
-//	  console.info('We are not primary but someone else is.');
+      //console.info('We are not primary but someone else is.');
       return;
     }
   }
@@ -123,14 +121,14 @@ const inReplicaSet = async (db, pods, status) => {
     return primaryWork(db, pods, members, true);
   }
 
-//  console.info('No primary, but another pod was elected to do primary work');
+  //console.info('No primary, but another pod was elected to do primary work');
   return;
 };
 
 const primaryWork = async (db, pods, members, shouldForce) => {
 
-//  console.info('Members: ', members);
-//  console.info('Pods: ', pods);
+  //console.info('Members: ', members);
+  //console.info('Pods: ', pods);
 
   // Loop over all the pods we have and see if any of them aren't in the current rs members array
   // If they aren't in there, add them
@@ -144,7 +142,7 @@ const primaryWork = async (db, pods, members, shouldForce) => {
     return mongo.addNewReplSetMembers(db, addrToAdd, addrToRemove, shouldForce);
   }
 
-//  console.info('Nothing to do.');
+  //console.info('Nothing to do.');
   return;
 };
 
@@ -193,7 +191,7 @@ const invalidReplicaSet = async (db, pods, status) => {
 
   console.warn('Invalid replica set');
   if (!podElection(pods)) {
-//    console.info('Didn\'t win the pod election, doing nothing');
+    //console.info('Didn\'t win the pod election, doing nothing');
     return;
   }
 
@@ -244,7 +242,7 @@ const addrToAddLoop = (pods, members) => {
       // If the node was not present, we prefer the stable network ID, if present.
       const addrToUse = podStableNetworkAddr || podIpAddr;
       addrToAdd.push(addrToUse);
-	  console.info('Detected new pod not in replicaset: '+addrToUse);
+      console.info('Detected new pod not in replicaset: '+addrToUse);
     }
   }
   return addrToAdd;
@@ -255,23 +253,23 @@ const addrToRemoveLoop = members => {
   for (const member of members) {
     if (memberShouldBeRemoved(member)) {
       addrToRemove.push(member.name);
-	  console.info('Detected unhealthy/missing pod in replicaset: '+member.name);
+      console.info('Detected unhealthy/missing pod in replicaset: '+member.name);
     }
   }
   return addrToRemove;
 };
 
 const memberShouldBeRemoved = member => {
-	if (!member.health)
-	{
-      let lastHeartbeatTick = Date.parse(member.lastHeartbeatRecv);
-      let nowTick = DateTime.utc();
-	  console.info('Member: '+member.name+' Last Heartbeat: '+lastHeartbeatTick+'  Now: '+nowTick);
-	  if (nowTick - lastHeartbeatTick > unhealthySeconds*1000)
-		return true;
-	}
-	return false;
-}
+  if (!member.health)
+  {
+    let lastHeartbeatTick = Date.parse(member.lastHeartbeatRecv);
+    let nowTick = DateTime.utc();
+    console.info('Member: '+member.name+' Last Heartbeat: '+lastHeartbeatTick+'  Now: '+nowTick);
+    if (nowTick - lastHeartbeatTick > unhealthySeconds*1000)
+      return true;
+  }
+  return false;
+};
 /**
  * @param pod this is the Kubernetes pod, containing the info.
  * @returns string - podIp the pod's IP address with the port from config attached at the end. Example

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -262,7 +262,7 @@ const addrToRemoveLoop = members => {
 };
 
 const memberShouldBeRemoved = member => !member.health
-      && DateTime.local().minus({ seconds: unhealthySeconds }) > DateTime.fromISO(member.lastHeartbeatRecv);
+      && DateTime.fromISO(member.lastHeartbeatRecv).valueOf() + { seconds: unhealthySeconds }*1000 > DateTime.utc();
 
 /**
  * @param pod this is the Kubernetes pod, containing the info.

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -113,7 +113,7 @@ const inReplicaSet = async (db, pods, status) => {
       if (member.self) return primaryWork(db, pods, members, false);
 
       primaryExists = true;
-	  console.info('We are not primary but someone else is.');
+//	  console.info('We are not primary but someone else is.');
       return;
     }
   }
@@ -123,14 +123,14 @@ const inReplicaSet = async (db, pods, status) => {
     return primaryWork(db, pods, members, true);
   }
 
-  console.info('No primary, but another pod was elected to do primary work');
+//  console.info('No primary, but another pod was elected to do primary work');
   return;
 };
 
 const primaryWork = async (db, pods, members, shouldForce) => {
 
-  console.info('Members: ', members);
-  console.info('Pods: ', pods);
+//  console.info('Members: ', members);
+//  console.info('Pods: ', pods);
 
   // Loop over all the pods we have and see if any of them aren't in the current rs members array
   // If they aren't in there, add them
@@ -144,7 +144,7 @@ const primaryWork = async (db, pods, members, shouldForce) => {
     return mongo.addNewReplSetMembers(db, addrToAdd, addrToRemove, shouldForce);
   }
 
-  console.info('Nothing to do.');
+//  console.info('Nothing to do.');
   return;
 };
 
@@ -193,7 +193,7 @@ const invalidReplicaSet = async (db, pods, status) => {
 
   console.warn('Invalid replica set');
   if (!podElection(pods)) {
-    console.info('Didn\'t win the pod election, doing nothing');
+//    console.info('Didn\'t win the pod election, doing nothing');
     return;
   }
 
@@ -267,7 +267,7 @@ const memberShouldBeRemoved = member => {
       let lastHeartbeatTick = Date.parse(member.lastHeartbeatRecv);
       let nowTick = DateTime.utc();
 	  console.info('Member: '+member.name+' Last Heartbeat: '+lastHeartbeatTick+'  Now: '+nowTick);
-	  if (lastHeartbeatTick + unhealthySeconds*1000 < nowTick)
+	  if (nowTick - lastHeartbeatTick > unhealthySeconds*1000)
 		return true;
 	}
 	return false;


### PR DESCRIPTION
Mongo 4.4.0 is stricter about only allowing one add or remove at a time, and no changes while an add or remove is taking place.  That means we can't add or remove multiple pods at once.  So I added a limit for that, except in the case where we are forcing.

There was a parsing error (at least for me) that left my removal broken.  The date was parsed as NaN somehow.  Switched to Date.parse and it got sorted out.  Now when I scale down, pods are really removed from the ReplicaSet, when they weren't before.

Since I'm not a JS programmer, I had to add a decent amount of logging to figure things out.  I left them in, but commented out the noisy ones so they won't waste log space, in case someone wants to work on this further, it's easier to get started.

Testing:  Scaling the statefulset from 2 -> 5 worked fine, deleting the primary worked fine, and scaling from 5 -> 1 worked fine.
